### PR TITLE
force install Node.js LTS 4.x version on Raspberry Pi

### DIFF
--- a/raspberrypi-node-blink.js
+++ b/raspberrypi-node-blink.js
@@ -2,7 +2,7 @@ var all = require('./all.js');
 var config = (all.fileExistsSync('../config.json')) ? require('../config.json') : require('../../config.json');
 var simssh = require('simple-ssh');
 var Q = require('q');
-var arg = require('get-gulp-args')();
+var args = require('get-gulp-args')();
 
 function initTasks(gulp) {
   var runSequence = require('run-sequence').use(gulp);

--- a/raspberrypi-node-blink.js
+++ b/raspberrypi-node-blink.js
@@ -2,10 +2,10 @@ var all = require('./all.js');
 var config = (all.fileExistsSync('../config.json')) ? require('../config.json') : require('../../config.json');
 var simssh = require('simple-ssh');
 var Q = require('q');
-var args = require('get-gulp-args')();
+var arg = require('get-gulp-args')();
 
 function initTasks(gulp) {
-  var runSequence = require('run-sequence').use(gulp);
+  var runSequence = require('run-sequence').use(gulp);
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'nodejs', 'RaspberryPi', 'blink');

--- a/raspberrypi-node-blink.js
+++ b/raspberrypi-node-blink.js
@@ -2,17 +2,17 @@ var all = require('./all.js');
 var config = (all.fileExistsSync('../config.json')) ? require('../config.json') : require('../../config.json');
 var simssh = require('simple-ssh');
 var Q = require('q');
-varÂ argsÂ =Â require('get-gulp-args')();
+var args = require('get-gulp-args')();
 
 function initTasks(gulp) {
-  varÂ runSequenceÂ =Â require('run-sequence').use(gulp);
+  var runSequence = require('run-sequence').use(gulp);
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'nodejs', 'RaspberryPi', 'blink');
   }
 
   gulp.task('install-tools', 'Installs required software on Raspberry Pi', function (cb) {
-    all.azhSshExec('sudo apt-get -y update && sudo apt-get -y install npm', config, args.verbose, cb);
+    all.azhSshExec('sudo apt-get -y update && sudo apt-get -y install npm && (curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -) && sudo apt-get -y install nodejs', config, args.verbose, cb);
   });
 
   gulp.task('deploy', 'Deploys sample code to the board', function(){


### PR DESCRIPTION
force install Node.js LTS 4.x version (by default RaspberryPi would use an very old version 0.10)
