### PR TITLE
capture CURL error, only proceed if HTTP status is 200

### DIFF
--- a/raspberrypi-node.js
+++ b/raspberrypi-node.js
@@ -18,7 +18,7 @@ function initTasks(gulp, options) {
   }
 
   gulp.task('install-tools', 'Installs required software on Raspberry Pi', function (cb) {
-    all.sshExecCmd('(curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -) && sudo apt-get -y install nodejs', config, args.verbose, cb);
+    all.sshExecCmd('(curl -sL http://deb.nodesource.com/setup_4.x --output ~/setup_4.x --write-out %{http_code} | grep 200) && sudo -E bash ~/setup_4.x && sudo apt-get -y install nodejs', config, args.verbose, cb);
   });
 
   gulp.task('deploy', 'Deploys sample code to the board', function (cb) {


### PR DESCRIPTION
Zim met this error when his Raspberry Pi has a wrong time setup.
Here the fix was trying to:
1. capture HTTP error, only proceeed when HTTP status is 200
2. use HTTP instead of HTTPS, to avoid the dependency over NTP server
