### PR TITLE
Zims rebased ssh plus config support

### DIFF
--- a/all.js
+++ b/all.js
@@ -391,7 +391,7 @@ function localRetrieve(url, options, cb) {
  * @returns {string}
  */
 function getToolsFolder() {
-  var folder = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'] + '/vsc-iot-tools';
+  var folder = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'] + '/.iot-hub-getting-started';
 
   if (!folderExistsSync(folder)) {
     fs.mkdirSync(folder);

--- a/all.js
+++ b/all.js
@@ -163,10 +163,10 @@ function sshExecCmd(cmd, options, cb) {
   } else if (config.device_password) {
     sshOptions.pass = config.device_password;
   } else {
-      let err = new Error("No password or SSH key defined");
-      err.stack = err.message;
-      cb(err);
-      return;    
+    let err = new Error("No password or SSH key defined");
+    err.stack = err.message;
+    cb(err);
+    return;    
   }
   
   var ssh = new simssh(sshOptions);

--- a/all.js
+++ b/all.js
@@ -422,7 +422,7 @@ function findSshKey() {
 function readGlobalConfig(postfix) {
   var filename = getToolsFolder() + '/config-' + postfix + '.json';
 
-  if (fileExistsSync()) {
+  if (fileExistsSync(filename)) {
     return require(filename);
   }
 

--- a/all.js
+++ b/all.js
@@ -485,7 +485,8 @@ module.exports = function (srcConfig) {
     download,
     gulpTaskBI,
     getToolsFolder,
-    writeConfigH
+    writeConfigH,
+    updateGlobalConfig
   }
 }
 

--- a/all.js
+++ b/all.js
@@ -358,7 +358,7 @@ function localRetrieve(url, options, cb) {
           // Ubuntu specific stuff, just use tar to uncompress all the other archives
           if (filename.endsWith('.tar.gz')) {
 
-            let cmds = [
+            var cmds = [
               'sudo tar xvz --file=' + path + ' -C ' + getToolsFolder(),
               'sudo rm ' + path];
 
@@ -367,7 +367,7 @@ function localRetrieve(url, options, cb) {
 
           } else if (filename.endsWith('.tar.xz')) {
 
-            let cmds = [
+            var cmds = [
               'sudo apt-get update',
               'sudo apt-get install -y wget xz-utils',
               'sudo tar xJ --file=' + path + ' -C ' + getToolsFolder(),
@@ -379,7 +379,7 @@ function localRetrieve(url, options, cb) {
         }
 
         // format is not supported yet on current platform
-        let err = new Error('Archive format not supported');
+        var err = new Error('Archive format not supported');
         cb(err);
       }
     });

--- a/all.js
+++ b/all.js
@@ -420,7 +420,7 @@ function findSshKey() {
  * @returns {object}
  */
 function readGlobalConfig(postfix) {
-  var filename = getToolsFolder() + '/config-' + prefix + '.json';
+  var filename = getToolsFolder() + '/config-' + postfix + '.json';
 
   if (fileExistsSync()) {
     return require(filename);
@@ -435,7 +435,7 @@ function readGlobalConfig(postfix) {
  * @param {object} config   - config object
  */
 function writeGlobalConfig(postfix, config) {
-  fs.writeFileSync(getToolsFolder() + '/config-' + prefix + '.json', JSON.stringify(config));
+  fs.writeFileSync(getToolsFolder() + '/config-' + postfix + '.json', JSON.stringify(config, null, 2));
 }
 
 /**
@@ -445,14 +445,14 @@ function writeGlobalConfig(postfix, config) {
  * @returns {object}
  */
 function updateGlobalConfig(postfix, template) {
-  var config = loadGlobalConfig(postfix);
+  var config = readGlobalConfig(postfix);
   var new_config = Object.assign(template, config);
 
   var old_config_string = JSON.stringify(config);
   var new_config_string = JSON.stringify(new_config);
 
   if (new_config_string != old_config_string) {
-    writeGlobalConfig(prefix, new_config);
+    writeGlobalConfig(postfix, new_config);
   }
 
   return new_config;

--- a/all.js
+++ b/all.js
@@ -421,7 +421,7 @@ function findSshKey() {
  */
 function readCombinedConfig(postfix) {
   var globalConfig = readGlobalConfig(postfix);
-  var localConfig = require(process.cwd() + '/config.json'); 
+  var localConfig = require(process.cwd() + '/config.json');
   var combinedConfig = Object.assign(globalConfig, localConfig);
   return combinedConfig;
 }

--- a/all.js
+++ b/all.js
@@ -25,20 +25,20 @@ function uploadFilesViaScp(sourceFileList, targetFileList, cb) {
     return;
   }
 
-  let scpOptions = {
+  var scpOptions = {
     host: config.device_host_name_or_ip_address,
     username: config.device_user_name,
     path: targetFileList[0]
   };
 
-  let sshKey = findSshKey();
+  var sshKey = findSshKey();
 
   if (sshKey) {
     scpOptions.privateKey = sshKey;
   } else if (config.device_password) {
     scpOptions.password = config.device_password;
   } else {
-    let err = new Error("No password or SSH key defined");
+    var err = new Error("No password or SSH key defined");
     err.stack = err.message;
     cb(err);
     return;
@@ -151,19 +151,19 @@ function localClone(url, folder, verbose, cb) {
  */
 function sshExecCmd(cmd, options, cb) {
 
-  let sshOptions = {
+  var sshOptions = {
     host: config.device_host_name_or_ip_address,
     user: config.device_user_name
   };
 
-  let sshKey = findSshKey();
+  var sshKey = findSshKey();
 
   if (sshKey) {
     sshOptions.key = sshKey;
   } else if (config.device_password) {
     sshOptions.pass = config.device_password;
   } else {
-    let err = new Error("No password or SSH key defined");
+    var err = new Error("No password or SSH key defined");
     err.stack = err.message;
     cb(err);
     return;

--- a/all.js
+++ b/all.js
@@ -465,10 +465,10 @@ function writeGlobalConfig(postfix, config) {
  * @returns {object}
  */
 function updateGlobalConfig(postfix, template) {
-  var config = readGlobalConfig(postfix);
-  var new_config = Object.assign(template, config);
+  var old_config = readGlobalConfig(postfix);
+  var new_config = Object.assign(template, old_config);
 
-  var old_config_string = JSON.stringify(config);
+  var old_config_string = JSON.stringify(old_config);
   var new_config_string = JSON.stringify(new_config);
 
   if (new_config_string != old_config_string) {

--- a/all.js
+++ b/all.js
@@ -415,6 +415,26 @@ function findSshKey() {
 }
 
 /**
+ * Loads combined config
+ * @param {string} postfix  - postfix appended to global config filename
+ * @returns {object}
+ */
+function readCombinedConfig(postfix) {
+  var globalConfig = readGlobalConfig(postfix);
+  var localConfig = require(process.cwd() + '/config.json'); 
+  var combinedConfig = Object.assign(global_config, local_config);
+  return combinedConfig;
+}
+
+/**
+ * Get loaded config
+ * @returns {object}
+ */
+function getConfig() {
+  return config;
+}
+
+/**
  * Loads selected config from user folder
  * @param {string} postfix  - postfix appended to config filename
  * @returns {object}
@@ -468,8 +488,8 @@ function writeConfigH() {
   }
 }
 
-module.exports = function (srcConfig) {
-  config = srcConfig;
+module.exports = function (options) {
+  config = readCombinedConfig(options.config_postfix);
 
   return {
     uploadFilesViaScp,
@@ -486,7 +506,7 @@ module.exports = function (srcConfig) {
     gulpTaskBI,
     getToolsFolder,
     writeConfigH,
-    updateGlobalConfig
+    updateGlobalConfig,
+    getConfig
   }
 }
-

--- a/all.js
+++ b/all.js
@@ -415,6 +415,50 @@ function findSshKey() {
 }
 
 /**
+ * Loads selected config from user folder
+ * @param {string} postfix  - postfix appended to config filename
+ * @returns {object}
+ */
+function readGlobalConfig(postfix) {
+  var filename = getToolsFolder() + '/config-' + prefix + '.json';
+
+  if (fileExistsSync()) {
+    return require(filename);
+  }
+
+  return {};
+}
+
+/**
+ * Writes selected config to user folder
+ * @param {string} postfix  - postfix appended to config filename
+ * @param {object} config   - config object
+ */
+function writeGlobalConfig(postfix, config) {
+  fs.writeFileSync(getToolsFolder() + '/config-' + prefix + '.json', JSON.stringify(config));
+}
+
+/**
+ * Updates or creates global config file
+ * @param {string} postfix    - postfix appended to config filename
+ * @param {object} template   - config template
+ * @returns {object}
+ */
+function updateGlobalConfig(postfix, template) {
+  var config = loadGlobalConfig(postfix);
+  var new_config = Object.assign(template, config);
+
+  var old_config_string = JSON.stringify(config);
+  var new_config_string = JSON.stringify(new_config);
+
+  if (new_config_string != old_config_string) {
+    writeGlobalConfig(prefix, new_config);
+  }
+
+  return new_config;
+}
+
+/**
  * Writes app/config.h file (for C and Arduino)
  */
 function writeConfigH() {

--- a/all.js
+++ b/all.js
@@ -41,7 +41,7 @@ function uploadFilesViaScp(sourceFileList, targetFileList, cb) {
     let err = new Error("No password or SSH key defined");
     err.stack = err.message;
     cb(err);
-    return;    
+    return;
   }
 
   scp2.scp(sourceFileList[0], scpOptions, function(err) {
@@ -166,9 +166,9 @@ function sshExecCmd(cmd, options, cb) {
     let err = new Error("No password or SSH key defined");
     err.stack = err.message;
     cb(err);
-    return;    
+    return;
   }
-  
+
   var ssh = new simssh(sshOptions);
 
   var output = '';
@@ -422,7 +422,7 @@ function findSshKey() {
 function readCombinedConfig(postfix) {
   var globalConfig = readGlobalConfig(postfix);
   var localConfig = require(process.cwd() + '/config.json'); 
-  var combinedConfig = Object.assign(global_config, local_config);
+  var combinedConfig = Object.assign(globalConfig, localConfig);
   return combinedConfig;
 }
 

--- a/all.js
+++ b/all.js
@@ -367,7 +367,7 @@ function localRetrieve(url, options, cb) {
 
           } else if (filename.endsWith('.tar.xz')) {
 
-            var cmds = [
+            let cmds = [
               'sudo apt-get update',
               'sudo apt-get install -y wget xz-utils',
               'sudo tar xJ --file=' + path + ' -C ' + getToolsFolder(),
@@ -379,7 +379,7 @@ function localRetrieve(url, options, cb) {
         }
 
         // format is not supported yet on current platform
-        var err = new Error('Archive format not supported');
+        let err = new Error('Archive format not supported');
         cb(err);
       }
     });

--- a/all.js
+++ b/all.js
@@ -469,17 +469,11 @@ function writeGlobalConfig(postfix, config) {
  */
 function updateGlobalConfig(postfix, template) {
   var configFilePath = getToolsFolder() + '/config-' + postfix + '.json';
-  console.log('Config file ' + configFilePath + ' was created / updated');
+  console.log('Create / update global config file at ' + configFilePath);
 
   var oldConfig = readGlobalConfig(postfix);
   var newConfig = Object.assign(template, oldConfig);
-
-  var oldConfigString = JSON.stringify(oldConfig);
-  var newConfigString = JSON.stringify(newConfig);
-
-  if (newConfigString != oldConfigString) {
-    writeGlobalConfig(postfix, newConfig);
-  }
+  writeGlobalConfig(postfix, newConfig);
 
   return newConfig;
 }

--- a/all.js
+++ b/all.js
@@ -420,9 +420,10 @@ function findSshKey() {
  * @returns {object}
  */
 function readCombinedConfig(postfix) {
+  var config = {};
   var globalConfig = readGlobalConfig(postfix);
   var localConfig = require(process.cwd() + '/config.json');
-  var combinedConfig = Object.assign(globalConfig, localConfig);
+  var combinedConfig = Object.assign(config, globalConfig, localConfig);
   return combinedConfig;
 }
 

--- a/arduino-adafruit-samd-feather-m0.js
+++ b/arduino-adafruit-samd-feather-m0.js
@@ -8,7 +8,7 @@
  * @param {object} gulp     - Gulp instance
  */
 function initTasks(gulp, options) {
-  var all = require('./all.js')(options.config);
+  var all = require('./all.js')(options);
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'c', 'feather_m0', ((options && options.appName) ? options.appName : 'unknown'));

--- a/arduino-edison.js
+++ b/arduino-edison.js
@@ -6,7 +6,7 @@
 var arduino = require('./arduino.js');
 
 function initTasks(gulp, options) {
-  var all = require('./all.js')(options.config);
+  var all = require('./all.js')(options);
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'c', 'edison', ((options && options.appName) ? options.appName : 'unknown'));

--- a/arduino-esp8266-huzzah.js
+++ b/arduino-esp8266-huzzah.js
@@ -8,7 +8,7 @@
  * @param {object} gulp     - Gulp instance
  */
 function initTasks(gulp, options) {
-  var all = require('./all.js')(options.config);
+  var all = require('./all.js')(options);
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'c', 'huzzah', ((options && options.appName) ? options.appName : 'unknown'));

--- a/arduino-esp8266-thingdev.js
+++ b/arduino-esp8266-thingdev.js
@@ -8,7 +8,7 @@
  * @param {object} gulp     - Gulp instance
  */
 function initTasks(gulp, options) {
-  var all = require('./all.js')(options.config);
+  var all = require('./all.js')(options);
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'c', 'thingdev', ((options && options.appName) ? options.appName : 'unknown'));

--- a/arduino.js
+++ b/arduino.js
@@ -14,8 +14,7 @@ var all;
  */
 function initTasks(gulp, options) {
   var runSequence = require('run-sequence').use(gulp);
-  var config = options.config;
-  all = require('./all.js')(config);
+  all = require('./all.js')(options);
 
   // package:arch:board[:parameters]
   var board_descriptor = options.board.package + ':' +

--- a/arduino.js
+++ b/arduino.js
@@ -15,6 +15,7 @@ var all;
 function initTasks(gulp, options) {
   var runSequence = require('run-sequence').use(gulp);
   all = require('./all.js')(options);
+  var config = all.getConfig();
 
   // package:arch:board[:parameters]
   var board_descriptor = options.board.package + ':' +

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@
  */
 function initTasks(gulp, boardId, options) {
   require('./' + boardId + '.js')(require('gulp-help')(gulp), options);
+  return gulp;
 }
 
 module.exports = initTasks;

--- a/raspberrypi-c.js
+++ b/raspberrypi-c.js
@@ -20,6 +20,15 @@ function initTasks(gulp, options) {
 
   var runSequence = require('run-sequence').use(gulp);
 
+  gulp.task('init', 'Initializes sample', function (cb) {
+    
+    if (options.config_prefix && options.config_template) {
+      all.updateGlobalConfig(options.config_prefix, options.config_template);
+    }
+
+    cb();
+  })
+  
   gulp.task('install-tools', 'Installs Raspberry Pi crosscompiler and libraries', function (cb) {
 
     // clone helper repository to tools folder -- if it doesn't exists

--- a/raspberrypi-c.js
+++ b/raspberrypi-c.js
@@ -22,8 +22,8 @@ function initTasks(gulp, options) {
 
   gulp.task('init', 'Initializes sample', function (cb) {
     
-    if (options.config_prefix && options.config_template) {
-      all.updateGlobalConfig(options.config_prefix, options.config_template);
+    if (options.config_postfix && options.config_template) {
+      all.updateGlobalConfig(options.config_postfix, options.config_template);
     }
 
     cb();

--- a/raspberrypi-c.js
+++ b/raspberrypi-c.js
@@ -12,7 +12,7 @@ var PREBUILT_FOLDER = all.getToolsFolder() + '/az-iot-sdk-prebuilt';
 var all;
 
 function initTasks(gulp, options) {
-  all = require('./all.js')(options.config);
+  all = require('./all.js')(options);
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'c', 'RaspberryPi', ((options && options.appName) ? options.appName : 'unknown'));

--- a/raspberrypi-c.js
+++ b/raspberrypi-c.js
@@ -21,14 +21,14 @@ function initTasks(gulp, options) {
   var runSequence = require('run-sequence').use(gulp);
 
   gulp.task('init', 'Initializes sample', function (cb) {
-    
+
     if (options.config_postfix && options.config_template) {
       all.updateGlobalConfig(options.config_postfix, options.config_template);
     }
 
     cb();
   })
-  
+
   gulp.task('install-tools', 'Installs Raspberry Pi crosscompiler and libraries', function (cb) {
 
     // clone helper repository to tools folder -- if it doesn't exists

--- a/raspberrypi-node.js
+++ b/raspberrypi-node.js
@@ -21,7 +21,7 @@ function initTasks(gulp, options) {
   }
 
   gulp.task('init', 'Initializes sample', function (cb) {
-    
+
     if (options.config_postfix && options.config_template) {
       all.updateGlobalConfig(options.config_postfix, options.config_template);
     }

--- a/raspberrypi-node.js
+++ b/raspberrypi-node.js
@@ -13,8 +13,7 @@ var fs = require('fs');
  */
 function initTasks(gulp, options) {
   var runSequence = require('run-sequence').use(gulp);
-  var config = options.config;
-  var all = require('./all.js')(config);
+  var all = require('./all.js')(options);
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'nodejs', 'RaspberryPi', ((options && options.appName) ? options.appName : 'unknown'));

--- a/raspberrypi-node.js
+++ b/raspberrypi-node.js
@@ -22,8 +22,8 @@ function initTasks(gulp, options) {
 
   gulp.task('init', 'Initializes sample', function (cb) {
     
-    if (options.config_prefix && options.config_template) {
-      all.updateGlobalConfig(options.config_prefix, options.config_template);
+    if (options.config_postfix && options.config_template) {
+      all.updateGlobalConfig(options.config_postfix, options.config_template);
     }
 
     cb();

--- a/raspberrypi-node.js
+++ b/raspberrypi-node.js
@@ -14,6 +14,7 @@ var fs = require('fs');
 function initTasks(gulp, options) {
   var runSequence = require('run-sequence').use(gulp);
   var all = require('./all.js')(options);
+  var config = all.getConfig();
 
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'nodejs', 'RaspberryPi', ((options && options.appName) ? options.appName : 'unknown'));

--- a/raspberrypi-node.js
+++ b/raspberrypi-node.js
@@ -20,6 +20,15 @@ function initTasks(gulp, options) {
     all.gulpTaskBI(gulp, 'nodejs', 'RaspberryPi', ((options && options.appName) ? options.appName : 'unknown'));
   }
 
+  gulp.task('init', 'Initializes sample', function (cb) {
+    
+    if (options.config_prefix && options.config_template) {
+      all.updateGlobalConfig(options.config_prefix, options.config_template);
+    }
+
+    cb();
+  })
+
   gulp.task('install-tools', 'Installs required software on Raspberry Pi', function (cb) {
     var ifNodeExist = "hash node 2>/dev/null";
     var ifNode4xOr6xExists = "(node -v | grep -q 'v[4|6]\.')";

--- a/raspberrypi-node.js
+++ b/raspberrypi-node.js
@@ -16,6 +16,9 @@ function initTasks(gulp, options) {
   var all = require('./all.js')(options);
   var config = all.getConfig();
 
+  // stick config into gulp object
+  gulp.config = config;
+
   if (typeof all.gulpTaskBI === 'function') {
     all.gulpTaskBI(gulp, 'nodejs', 'RaspberryPi', ((options && options.appName) ? options.appName : 'unknown'));
   }


### PR DESCRIPTION
This commit contains finally agreed SSH key support and support for global and local config

SSH key Support:
if device_key_path present in configuration file implementation will attempt to read the key
if key not read successfully password will be used (if presen)
if no key and no password, SCP and SSH will fail

Config support
- config template and config file postfix specified in options
- local and global config combined and sticked into gulp instance
- gulp init task implemented
