### PR TITLE
Change ssh timeout from 10 seconds to 30 seconds

### DIFF
--- a/all.js
+++ b/all.js
@@ -154,7 +154,8 @@ function localClone(url, folder, verbose, cb) {
 function sshExecCmd(cmd, options, cb) {
   var sshOptions = {
     host: config.device_host_name_or_ip_address,
-    user: config.device_user_name
+    user: config.device_user_name,
+    timeout: 30000
   };
 
   var sshKey = findSshKey();


### PR DESCRIPTION
@zikalino 

When running gulp tasks against Intel Edison board at home, timeout always happened with below error.

C:\Users\zhijzhao\iot-hub-node-raspberrypi-getting-started\Lesson1>gulp --verbose
[18:42:00] Using gulpfile ~\iot-hub-node-raspberrypi-getting-started\Lesson1\gulpfile.js
[18:42:00] Starting 'default'...
[18:42:00] Starting 'install-tools'...
[18:42:11] 'install-tools' errored after 10 s
[18:42:11] ERROR: Timed out while waiting for handshake
[18:42:11] 'default' errored after 10 s

Changing the default 10 seconds timeout to 20 seconds solves my issue. Here I change it to 30 seconds in case some user has more slower experience than me. 
