### PR TITLE
Improve Edison C install-tools experience

### DIFF
--- a/edison-c.js
+++ b/edison-c.js
@@ -79,6 +79,15 @@ function initTasks(gulp, options) {
     runSequence('clone-iot-sdk', 'change-make-parallelism-to-2', 'build-iot-sdk', cb);
   });
 
+  gulp.task('clean', 'Remove installed SDK and deployed sample code from device', function (cb) {
+    all.sshExecCmds(["rm -rf ~/azure-iot-sdks",
+      "rm -rf " + targetFolder],
+      {
+        verbose: args.verbose,
+        sshPrintCommands: true,
+        validate: true
+      }, cb);
+  });
 
   gulp.task('deploy', 'Deploy and build sample code on the device', function (cb) {
     let src = [];

--- a/edison-c.js
+++ b/edison-c.js
@@ -34,10 +34,6 @@ function initTasks(gulp, options) {
     cb();
   });
 
-  gulp.task('install-mraa', false, function (cb) {
-    all.sshExecCmd("opkg install mraa", { verbose: args.verbose }, cb);
-  });
-
   gulp.task('clone-iot-sdk', false, function (cb) {
     all.sshExecCmds(["if [ ! -d ~/azure-iot-sdks ]; " +
       "then git clone https://github.com/Azure/azure-iot-sdks.git && cd ~/azure-iot-sdks && git checkout a291a82; fi",
@@ -70,7 +66,8 @@ function initTasks(gulp, options) {
   });
 
   gulp.task('build-iot-sdk', false, function (cb) {
-    all.sshExecCmds(["cd ~/azure-iot-sdks && sudo c/build_all/linux/build.sh --skip-unittests --no-amqp --no-http --no_uploadtoblob"],
+    all.sshExecCmds(["test -e ~/azure-iot-sdks/c/cmake/iotsdk_linux/iothub_client/libiothub_client_mqtt_transport.a || " +
+      "(cd ~/azure-iot-sdks && sudo c/build_all/linux/build.sh --skip-unittests --no-amqp --no-http --no_uploadtoblob)"],
       {
         verbose: args.verbose,
         sshPrintCommands: true,
@@ -79,7 +76,7 @@ function initTasks(gulp, options) {
   });
 
   gulp.task('install-tools', 'Installs required software on the device', function (cb) {
-    runSequence('install-mraa', 'clone-iot-sdk', 'change-make-parallelism-to-2', 'build-iot-sdk', cb);
+    runSequence('clone-iot-sdk', 'change-make-parallelism-to-2', 'build-iot-sdk', cb);
   });
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-common",
-  "version": "v0.11.5",
+  "version": "v0.11.6",
   "description": "Azure IoT Samples common gulp tasks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@xscript @zikalino @aovechki 

1. remove mraa installation for it's been installed for newly flashed device.
2. skip building iot sdk if it's built before.
3. add gulp clean task that can delete installed sdk and deployed sample code from device. 